### PR TITLE
Backwards-compatible type annotations where necessary

### DIFF
--- a/oefdb/validate.py
+++ b/oefdb/validate.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Dict
+
 import click
 from pandas import DataFrame
 
@@ -10,7 +12,7 @@ from oefdb.validators.check_ids_for_unsupported_characters import (
 )
 from oefdb.validators.check_oefdb_structure import check_oefdb_structure
 
-results_from_validators_type = dict[str, validator_result_type]
+results_from_validators_type = Dict[str, validator_result_type]
 
 
 def validate(oefdb_df: DataFrame) -> tuple[bool, results_from_validators_type]:

--- a/oefdb/validators/_typing.py
+++ b/oefdb/validators/_typing.py
@@ -1,3 +1,5 @@
 from __future__ import annotations
 
-validator_result_type = tuple[bool, list[str]]
+from typing import List, Tuple
+
+validator_result_type = Tuple[bool, List[str]]


### PR DESCRIPTION
This resolves the failing CI checks related to type annotations. [SO](https://stackoverflow.com/questions/63460126/typeerror-type-object-is-not-subscriptable-in-a-function-signature)