### PR TITLE
Make tox work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ test.db
 .ipynb_checkpoints
 dist
 .env
+
+# Some of our tests write this file
+*OpenEmissionFactorsDB.csv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 packages = [{ include = "oefdb" }]
 
 [tool.poetry.dependencies]
-python = ">=3.7.1,<3.10.0"
+python = ">=3.7.1,<=3.10.4"
 PyGithub = ">=1.55,<2.0"
 pandas = ">=1.3.4,<2.0.0"
 ipywidgets = ">=7.6.5,<8.0.0"

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 isolated_build = True
-envlist = py{3.7,3.8,3.9}
+envlist = py{37,38,39}
 
 [testenv]
 whitelist_externals = poetry
 commands =
+    poetry install -v
     poetry run poe {posargs}


### PR DESCRIPTION
So I realized while working on my other PR that tox actually didn't work - it always used the system interpreter, leading my test runs to pass locally while failing in CI (that doesn't use tox, but uses actual system environments)

That's because we had misspelled the tox environments :sweat: - but it seems to work now!

