### PR TITLE
Add functionality to limit a column to a set of allowed values

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ This SDK supports schema-based validation, where a schema is defined in a TOML f
 name = "kgCO2e-AR5"
 allow_empty = true
 validators = ["is_float_or_not_supplied"]
+allowed_values = [
+    "foo",
+    "bar"
+]
 
 [[columns]]
 # ... next column here
@@ -83,6 +87,8 @@ Then an `allow_empty` - if this is set to true, empty values are always allowed.
 empty values are never allowed.
 Afterwards, a list of `validators` - which is the name of functions that take the value and ensure it lives up to some sort of standard.
 These are only called if the value is not-empty.
+An optional property, `allowed_values` can be set, if only a predetermined list of values are allowed to be in this field. If `allow_empty` is set to true,
+empty values are allowed, even if they are not in the `allowed_values` list.
 
 ### Cell validators
 A list of all the cell validators currently

--- a/oefdb/validators/schema/cell_validator_functions.py
+++ b/oefdb/validators/schema/cell_validator_functions.py
@@ -28,7 +28,7 @@ valid_id_punctuation_regex = re.compile(r"-|_|\.")
 
 
 def is_valid_activity_id(cell_value: str) -> cell_validator_return_type:
-    # If we have an alphanumeric string after removing all valid punctuation, then our ID is legal
+    # If we have an alphanumeric string after removing all valid punctuation, then our ID is valid
     value_without_punctuation = re.sub(valid_id_punctuation_regex, "", cell_value)
     if not value_without_punctuation.isalnum():
         return 'Cell contains invalid punctuation. IDs can only contain alphanumeric characters and "-", "_" and "."'

--- a/oefdb/validators/schema/column_schema.py
+++ b/oefdb/validators/schema/column_schema.py
@@ -28,7 +28,6 @@ class ColumnSchema(BaseModel):
                     "allow_empty": "The cell was empty, but empty cells are not allowed."
                 }
 
-        # print(self.allowed_values)
         if self.allowed_values:
             if cell_value not in self.allowed_values:
                 return {

--- a/oefdb/validators/schema/column_schema.py
+++ b/oefdb/validators/schema/column_schema.py
@@ -11,6 +11,7 @@ class ColumnSchema(BaseModel):
     column_name: str = Field(alias="name")
     validators: typing.List[CellValidator]
     allow_empty: bool
+    allowed_values: typing.Union[None, typing.List[str]]
 
     def validate_cell(self, cell_value: str) -> None | dict[str, str]:
         """
@@ -25,6 +26,13 @@ class ColumnSchema(BaseModel):
             else:
                 return {
                     "allow_empty": "The cell was empty, but empty cells are not allowed."
+                }
+
+        print(self.allowed_values)
+        if self.allowed_values:
+            if cell_value not in self.allowed_values:
+                return {
+                    "allowed_values": f"The value '{cell_value}' was not part of the 'allowed_values' list. Please edit the cell or the list of allowed values."
                 }
 
         all_errors = {}

--- a/oefdb/validators/schema/column_schema.py
+++ b/oefdb/validators/schema/column_schema.py
@@ -28,7 +28,7 @@ class ColumnSchema(BaseModel):
                     "allow_empty": "The cell was empty, but empty cells are not allowed."
                 }
 
-        print(self.allowed_values)
+        # print(self.allowed_values)
         if self.allowed_values:
             if cell_value not in self.allowed_values:
                 return {

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-;addopts = --cov=oefdb --cov-report term-missing --verbose
+addopts = --cov=oefdb --cov-report term-missing --verbose
 testpaths = tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --cov=oefdb --cov-report term-missing --verbose
+;addopts = --cov=oefdb --cov-report term-missing --verbose
 testpaths = tests

--- a/tests/validators/schema/test_full_schema_validation.py
+++ b/tests/validators/schema/test_full_schema_validation.py
@@ -1,5 +1,3 @@
-import pprint
-
 from oefdb.validators.schema.cell_validators import IsValidActivityIdCellValidator, IsAsciiCellValidator
 from oefdb.validators.schema.column_schema import ColumnSchema
 from oefdb.validators.schema.schema import Schema
@@ -176,7 +174,6 @@ def test_validation_rejects_values_not_in_allowed_values():
 
     schema = Schema.from_toml_string(toml_conf)
 
-    pprint.pp(schema)
     validation_result = schema.validate_all(csv)
 
     assert validation_result.is_valid() is False

--- a/tests/validators/schema/test_full_schema_validation.py
+++ b/tests/validators/schema/test_full_schema_validation.py
@@ -1,3 +1,5 @@
+from oefdb.validators.schema.cell_validators import IsValidActivityIdCellValidator, IsAsciiCellValidator
+from oefdb.validators.schema.column_schema import ColumnSchema
 from oefdb.validators.schema.schema import Schema
 
 
@@ -146,6 +148,89 @@ def test_validation_is_empty_rejects_empty_values_if_set_to_false():
         2: {
             "hello": {
                 "allow_empty": "The cell was empty, but empty cells are not allowed."
+            }
+        },
+    }
+
+
+def test_validation_rejects_values_not_in_allowed_values():
+    csv = [
+        ["hello", "world"],
+        ["", "2013"],
+    ]
+
+    schema = Schema(
+        columns=[
+            ColumnSchema(
+                name="hello", validators=[], allow_empty=True
+            ),
+            ColumnSchema(
+                name="world", validators=[], allow_empty=True, allowed_values=["2014"]
+            ),
+        ]
+    )
+
+    validation_result = schema.validate_all(csv)
+
+    assert validation_result.is_valid() is False
+    assert not validation_result.column_errors
+
+    assert validation_result.row_errors == {
+        2: {
+            "world": {
+                "allowed_values": "The value '2013' was not part of the 'allowed_values' list. Please edit the cell or the list of allowed values."
+            }
+        },
+    }
+
+def test_validation_does_not_reject_empty_values_if_allow_empty_is_set_to_true_even_if_value_is_not_in_allowed_values():
+    csv = [
+        ["hello", "world"],
+        ["", ""],
+    ]
+
+    schema = Schema(
+        columns=[
+            ColumnSchema(
+                name="hello", validators=[], allow_empty=True
+            ),
+            ColumnSchema(
+                name="world", validators=[], allow_empty=True, allowed_values=["2014"]
+            ),
+        ]
+    )
+
+    validation_result = schema.validate_all(csv)
+
+    assert validation_result.is_valid() is True
+
+
+def test_validation_still_fails_on_elements_in_allowed_values_if_validator_fails():
+    csv = [
+        ["hello", "world"],
+        ["", "æøå"],
+    ]
+
+    schema = Schema(
+        columns=[
+            ColumnSchema(
+                name="hello", validators=[], allow_empty=True
+            ),
+            ColumnSchema(
+                name="world", validators=[IsAsciiCellValidator], allow_empty=True, allowed_values=["æøå"]
+            ),
+        ]
+    )
+
+    validation_result = schema.validate_all(csv)
+
+    assert validation_result.is_valid() is False
+    assert not validation_result.column_errors
+
+    assert validation_result.row_errors == {
+        2: {
+            "world": {
+                "is_ascii": "String 'æøå' contains disallowed non-ASCII characters. First invalid character is 'æ' at index 0."
             }
         },
     }

--- a/tests/validators/schema/test_full_schema_validation.py
+++ b/tests/validators/schema/test_full_schema_validation.py
@@ -1,3 +1,5 @@
+import pprint
+
 from oefdb.validators.schema.cell_validators import IsValidActivityIdCellValidator, IsAsciiCellValidator
 from oefdb.validators.schema.column_schema import ColumnSchema
 from oefdb.validators.schema.schema import Schema
@@ -159,17 +161,22 @@ def test_validation_rejects_values_not_in_allowed_values():
         ["", "2013"],
     ]
 
-    schema = Schema(
-        columns=[
-            ColumnSchema(
-                name="hello", validators=[], allow_empty=True
-            ),
-            ColumnSchema(
-                name="world", validators=[], allow_empty=True, allowed_values=["2014"]
-            ),
-        ]
-    )
+    toml_conf = """
+        [[columns]]
+        name = "hello"
+        validators = []
+        allow_empty = true
 
+        [[columns]]
+        name = "world"
+        validators = []
+        allow_empty = true
+        allowed_values = ["2014"]
+        """
+
+    schema = Schema.from_toml_string(toml_conf)
+
+    pprint.pp(schema)
     validation_result = schema.validate_all(csv)
 
     assert validation_result.is_valid() is False

--- a/tests/validators/schema/test_full_schema_validation.py
+++ b/tests/validators/schema/test_full_schema_validation.py
@@ -1,4 +1,4 @@
-from oefdb.validators.schema.cell_validators import IsValidActivityIdCellValidator, IsAsciiCellValidator
+from oefdb.validators.schema.cell_validators import IsAsciiCellValidator
 from oefdb.validators.schema.column_schema import ColumnSchema
 from oefdb.validators.schema.schema import Schema
 
@@ -187,6 +187,7 @@ def test_validation_rejects_values_not_in_allowed_values():
         },
     }
 
+
 def test_validation_does_not_reject_empty_values_if_allow_empty_is_set_to_true_even_if_value_is_not_in_allowed_values():
     csv = [
         ["hello", "world"],
@@ -195,9 +196,7 @@ def test_validation_does_not_reject_empty_values_if_allow_empty_is_set_to_true_e
 
     schema = Schema(
         columns=[
-            ColumnSchema(
-                name="hello", validators=[], allow_empty=True
-            ),
+            ColumnSchema(name="hello", validators=[], allow_empty=True),
             ColumnSchema(
                 name="world", validators=[], allow_empty=True, allowed_values=["2014"]
             ),
@@ -217,11 +216,12 @@ def test_validation_still_fails_on_elements_in_allowed_values_if_validator_fails
 
     schema = Schema(
         columns=[
+            ColumnSchema(name="hello", validators=[], allow_empty=True),
             ColumnSchema(
-                name="hello", validators=[], allow_empty=True
-            ),
-            ColumnSchema(
-                name="world", validators=[IsAsciiCellValidator], allow_empty=True, allowed_values=["æøå"]
+                name="world",
+                validators=[IsAsciiCellValidator],
+                allow_empty=True,
+                allowed_values=["æøå"],
             ),
         ]
     )


### PR DESCRIPTION
This PR adds an extra top-level column attribute in the TOML schema file - `allowed_values`.

This can be set when you have a field that is not supposed to vary much, such as `category`, `source`, `lca_activity` etc. This will force people to update the schema file if they want to add a new category or similar.

It does not allow for using any of the metadata CSV files that currently exist in the OEFDB, so we will need a little bit of data duplication into the `schema.toml` file, but I think that's an acceptable tradeoff for now.